### PR TITLE
Add a `make dist` target to package the dashboards.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+VERSION?=$(shell git rev-parse --abbrev-ref HEAD)
+
+.PHONY: dist
+dist:
+	git archive --format tar.gz --prefix beats-dashboards-$(VERSION)/ -o ../beats-dashboards-$(VERSION).tar.gz HEAD

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Packetbeat dashboards
-=====================
+Beats dashboards
+================
 
 This repository contains sample Kibana4 dashboards for visualizing the data
 gathered by the Elastic [Beats](https://www.elastic.co/products/beats).


### PR DESCRIPTION
Uses the branch name to determine the version number. Also replaces
Packetbeat with Beats in the README title.
