### PR TITLE
Replace grep with awk to extract the index pattern title

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -114,7 +114,7 @@ done
 
 for file in $DIR/index-pattern/*.json
 do
-    name=`grep -oP '"title": "\K[A-Z0-9a-z_#\-*]*' $file`
+    name=`awk '$1 == "\"title\":" {gsub(/"/, "", $2); print $2}' $file`
     echo "Loading index pattern $name:"
 
     $CURL -XPUT $ELASTICSEARCH/$KIBANA_INDEX/index-pattern/$name \


### PR DESCRIPTION
The default version of the `grep` command doesn't support -P option, so I am replacing it with `awk` to extract the title from the index pattern file.

The fix requires testing on:
- [x] OSX
- [x] Linux
