### PR TITLE
Enable to rename hardcoded index names in visualizations for #69

### DIFF
--- a/.beatconfig
+++ b/.beatconfig
@@ -1,5 +1,5 @@
-packetbeat-/rocketbeat-
-filebeat-/rawbeat-
-topbeat-/greatbeat-
-winlogonbeat-/win98beat-
+packetbeat-/packetbeat-
+filebeat-/filebeat-
+topbeat-/topbeat-
+winlogonbeat-/winlogonbeat-
 logstash-/logstash-

--- a/.beatconfig
+++ b/.beatconfig
@@ -1,0 +1,5 @@
+packetbeat-/rocketbeat-
+filebeat-/rawbeat-
+topbeat-/greatbeat-
+winlogonbeat-/win98beat-
+logstash-/logstash-

--- a/load.sh
+++ b/load.sh
@@ -10,10 +10,11 @@
 ELASTICSEARCH=http://localhost:9200
 CURL=curl
 KIBANA_INDEX=".kibana"
+BEAT_CONFIG=".beatconfig"
 
 print_usage() {
   echo "
-  
+
 Load the dashboards, visualizations and index patterns into the given
 Elasticsearch instance.
 
@@ -82,17 +83,32 @@ esac
 shift 2
 done
 
+if [ -f ${BEAT_CONFIG} ]; then
+  for ln in `cat ${BEAT_CONFIG}`; do
+    BUILD_STRING="${BUILD_STRING}s/${ln}/g;"
+  done
+  SED_STRING=`echo ${BUILD_STRING} | sed 's/;$//'`
+fi
+# Failsafe OR we will not do any SED later on - needs to decide which is safer or better
+if [ -z ${SED_STRING} ]; then
+  SED_STRING="s/packetbeat-/packetbeat-/g;s/filebeat-/filebeat-/g;s/topbeat-/topbeat-/g;s/winlogonbeat-/winlogonbeat-/g"
+fi
+
 DIR=dashboards
 echo "Loading dashboards to ${ELASTICSEARCH} in ${KIBANA_INDEX}"
 
+TMP_SED_FILE="${DIR}/search/tmp_search.json"
 for file in ${DIR}/search/*.json
 do
     NAME=`basename ${file} .json`
     echo "Loading search ${NAME}:"
+
+    sed ${SED_STRING} ${file} > ${TMP_SED_FILE}
     ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/search/${NAME} \
-        -d @${file} || exit 1
+        -d @${TMP_SED_FILE} || exit 1
     echo
 done
+rm ${TMP_SED_FILE}
 
 for file in ${DIR}/visualization/*.json
 do
@@ -121,5 +137,3 @@ do
         -d @${file} || exit 1
     echo
 done
-
-


### PR DESCRIPTION
This modification expect a configuration file (.beatconfig), where necessary renaming is defined.
Configuration file can be empty or doesn't need to exist.
Script doesn't touch original files, it creates temp files instead.
It works with other custom visualizations - just add your names and your set to go.
It has also 'fallback' option if there is no configuration file - it is questionable what to do - do we 'sed' when there is no change? 
Also 'tokens' can be configurable?
This solution requires further discussion.
