### PR TITLE
fixing nav links to work when kibana is configured with server.basePath

### DIFF
--- a/dashboards/visualization/Navigation.json
+++ b/dashboards/visualization/Navigation.json
@@ -1,5 +1,5 @@
 {
-  "visState": "{\"type\":\"markdown\",\"params\":{\"markdown\":\"###Packetbeat:\\n\\n[Dashboard](/#/dashboard/Packetbeat-Dashboard)\\n\\n[Web transactions](/#/dashboard/HTTP)\\n\\n[MySQL performance](/#/dashboard/MySQL-performance)\\n\\n[PostgreSQL performance](/#/dashboard/PgSQL-performance)\\n\\n[MongoDB performance](/#/dashboard/MongoDB-performance)\\n\\n[Thrift-RPC performance](/#/dashboard/Thrift-performance)\\n\\n###Topbeat:\\n\\n[Dashboard](/#/dashboard/Topbeat-Dashboard)\\n\\n###Winlogbeat:\\n\\n[Dashboard](/#/dashboard/Winlogbeat-Dashboard)\"},\"aggs\":[],\"listeners\":{}}", 
+  "visState": "{\"type\":\"markdown\",\"params\":{\"markdown\":\"###Packetbeat:\\n\\n[Dashboard](#/dashboard/Packetbeat-Dashboard)\\n\\n[Web transactions](#/dashboard/HTTP)\\n\\n[MySQL performance](#/dashboard/MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Thrift-performance)\\n\\n###Topbeat:\\n\\n[Dashboard](#/dashboard/Topbeat-Dashboard)\\n\\n###Winlogbeat:\\n\\n[Dashboard](#/dashboard/Winlogbeat-Dashboard)\"},\"aggs\":[],\"listeners\":{}}", 
   "description": "", 
   "title": "Navigation", 
   "uiStateJSON": "{}", 


### PR DESCRIPTION
Removed starting slash for when kibana is running behind a proxy, using `server.basePath`.

Tested both direct and using the following configs:
#### kibana.yml

```
server.basePath: "/kibana"
```
#### nginx config

```
        location /kibana/ {
          proxy_pass  http://kibana/;
          proxy_buffering    off;
          proxy_set_header   Host             $host;
          proxy_set_header   X-Real-IP        $remote_addr;
          proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
        }
```
