### PR TITLE
fix "Index pattern interval" name with brackets

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -117,7 +117,7 @@ do
     NAME=`awk '$1 == "\"title\":" {gsub(/[",]/, "", $2); print $2}' ${file}`
     echo "Loading index pattern ${NAME}:"
 
-    ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/index-pattern/${NAME} \
+    ${CURL} --globoff -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/index-pattern/${NAME} \
         -d @${file} || exit 1
     echo
 done


### PR DESCRIPTION
fix "Index pattern interval" name with brackets  
e.g. `[filebeat]-YYYY.MM.DD`

without `--globoff` we get `[globbing] error: bad range specification`
