### PR TITLE
Fix mapping issue when used together with Timelion

### DIFF
--- a/load.ps1
+++ b/load.ps1
@@ -88,6 +88,9 @@ if ($KIBANA_INDEX -eq "") {
 $DIR="./dashboards"
 echo "Loading dashboards to $ELASTICSEARCH in $KIBANA_INDEX"  
 
+&$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX" -Method PUT
+&$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/_mapping/search" -Method PUT -Body '{"search": {"properties": {"hits": {"type": "integer"}, "version": {"type": "integer"}}}}'
+
 ForEach ($file in Get-ChildItem "$DIR/search/" -Filter *.json) {
   $name = [io.path]::GetFileNameWithoutExtension($file.Name)
   echo "Loading search $($name):"

--- a/load.sh
+++ b/load.sh
@@ -85,6 +85,10 @@ done
 DIR=dashboards
 echo "Loading dashboards to $ELASTICSEARCH in $KIBANA_INDEX"  
 
+# Workaround for: https://github.com/elastic/beats-dashboards/issues/94
+$CURL -XPUT "$ELASTICSEARCH/$KIBANA_INDEX"
+$CURL -XPUT "$ELASTICSEARCH/$KIBANA_INDEX/_mapping/search" -d'{"search": {"properties": {"hits": {"type": "integer"}, "version": {"type": "integer"}}}}'
+
 for file in $DIR/search/*.json
 do
     name=`basename $file .json`


### PR DESCRIPTION
This explicitly sets the `type` and `hits` fields to integer, because
otherwise ES guesses `long`, which Timelion tries to change into integer
when it first loads and it fails.

Should fix #94.

I didn't yet test on Windows, will do that and set the review label afterwards.
