### PR TITLE
Add a link to the NFS dashboard in the Navigation

### DIFF
--- a/dashboards/visualization/Navigation.json
+++ b/dashboards/visualization/Navigation.json
@@ -1,6 +1,5 @@
 {
   "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"###Packetbeat:\\n\\n[Dashboard](#/dashboard/Packetbeat-Dashboard)\\n\\n[Web transactions](#/dashboard/HTTP)\\n\\n[MySQL performance](#/dashboard/MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Thrift-performance)\\n\\n[NFS performance](#/dashboard/NFS-packetbeat)\\n\\n###Topbeat:\\n\\n[Dashboard](#/dashboard/Topbeat-Dashboard)\\n\\n###Winlogbeat:\\n\\n[Dashboard](#/dashboard/Winlogbeat-Dashboard)\"},\"aggs\":[],\"listeners\":{}}", 
->>>>>>> Add a link to the NFS dashboard in the Navigation
   "description": "", 
   "title": "Navigation", 
   "uiStateJSON": "{}", 

--- a/dashboards/visualization/Navigation.json
+++ b/dashboards/visualization/Navigation.json
@@ -1,5 +1,6 @@
 {
-  "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"###Packetbeat:\\n\\n[Overview](/#/dashboard/Packetbeat-Dashboard)\\n\\n[Web transactions](/#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](/#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](/#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](/#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](/#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](/#/dashboard/Packetbeat-NFS)\"},\"aggs\":[],\"listeners\":{}}", 
+  "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"###Packetbeat:\\n\\n[Dashboard](#/dashboard/Packetbeat-Dashboard)\\n\\n[Web transactions](#/dashboard/HTTP)\\n\\n[MySQL performance](#/dashboard/MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Thrift-performance)\\n\\n[NFS performance](#/dashboard/NFS-packetbeat)\\n\\n###Topbeat:\\n\\n[Dashboard](#/dashboard/Topbeat-Dashboard)\\n\\n###Winlogbeat:\\n\\n[Dashboard](#/dashboard/Winlogbeat-Dashboard)\"},\"aggs\":[],\"listeners\":{}}", 
+>>>>>>> Add a link to the NFS dashboard in the Navigation
   "description": "", 
   "title": "Navigation", 
   "uiStateJSON": "{}", 


### PR DESCRIPTION
Fixes https://github.com/elastic/beats-dashboards/issues/104

Before including the dashboard, we need to fix the errors that the NFS dashboards throws when opening it without any NFS data.
