### PR TITLE
Fix curl command for the -u param

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -55,7 +55,7 @@ case $1 in
             print_usage
             exit 1
         fi
-        CURL="curl --user $USER"
+        CURL="$CURL --user $USER"
         ;;
 
     -i | -index )


### PR DESCRIPTION
Make it use the CURL variable. This makes the workaround
for alpha5 easier to apply.
