### PR TITLE
#122 fix readme's command ( pip install -r requirements.txt is not working )

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Create a new dashboard
 ----------------------
 
 If you added support for a new protocol in Packetbeat or a module in
-Metricbeat, it would be nice to create a dedicated Kibana dashboard to 
+Metricbeat, it would be nice to create a dedicated Kibana dashboard to
 visualize your data.
 The Kibana dashboards are saved in a special index in Elasticsearch. By default
 it's `.kibana`, but it can be configured to anything else.
 
 The first step in creating your own Kibana dashboard is to get a fresh
 installation of the Kibana dashboards/visualizations/searches/index patterns,
-that you can use as a starting point for your own dashboard. You can use the 
-`load.sh` script on Unix and `load.ps1` on Windows for loading the sample 
+that you can use as a starting point for your own dashboard. You can use the
+`load.sh` script on Unix and `load.ps1` on Windows for loading the sample
 dashboards/visualizations/searches/index patterns in Kibana. The usage of this
 script is described above.
 
@@ -53,8 +53,8 @@ Note: Make sure you are using the latest Kibana version to create and download
 the dashboards.
 
 Then, you can create the dashboard together with the necessary
-visualizations and searches in Kibana. After the dashboard is ready, you can download 
-all the dashboards using the `save/kibana_dump.py` script. 
+visualizations and searches in Kibana. After the dashboard is ready, you can download
+all the dashboards using the `save/kibana_dump.py` script.
 
 Before executing the save/kibana_dump.py script, make sure you have python and virtualenv
 installed:
@@ -62,7 +62,7 @@ installed:
         # Prepare the environment
         virtualenv env
         . env/bin/activate
-        pip install -r requirements.txt
+        pip install -r save/requirements.txt
 
         # go to save directory
         cd save


### PR DESCRIPTION
`pip install -r requirements.txt` is not working.

```
$ pip install -r requirements.txt
Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
```

I thinks this command should be `pip install -r save/requirements.txt`.
Thanks!
